### PR TITLE
Supress the persistent console window.

### DIFF
--- a/windowpadx/tools/chocolateyInstall.ps1
+++ b/windowpadx/tools/chocolateyInstall.ps1
@@ -3,4 +3,9 @@ $md5checksum = "d8f0dbda3bcdc751dee257900db081e8"
 
 $exePath = Join-Path $env:chocolateyPackageFolder 'WindowPadX.exe'
 
+$dotguiPath = $exePath + ".gui"
+if(!(Test-Path $dotguiPath)) {
+  New-Item $dotguiPath
+}
+
 Get-ChocolateyWebFile $env:chocolateyPackageName $exePath $url -checksum $md5checksum -checksumType "md5"


### PR DESCRIPTION
Per (these)[https://github.com/chocolatey/choco/wiki/CreatePackages#how-do-i-exclude-executables-from-getting-batch-redirects] instructions I tweaked the install so the console window doesn't hang around.
